### PR TITLE
Change protocol encoding to UTF-8

### DIFF
--- a/src/MpcCore/MpcCoreConnection.cs
+++ b/src/MpcCore/MpcCoreConnection.cs
@@ -90,8 +90,9 @@ namespace MpcCore
 			await _tcpClient.ConnectAsync(_endPoint.Address, _endPoint.Port);
 
 			_networkStream = _tcpClient.GetStream();
-			_reader = new StreamReader(_networkStream, Encoding.ASCII);
-			_writer = new StreamWriter(_networkStream, Encoding.ASCII) { NewLine = "\n" };
+			var encoding = new UTF8Encoding(false, true);
+			_reader = new StreamReader(_networkStream, encoding);
+			_writer = new StreamWriter(_networkStream, encoding) { NewLine = "\n" };
 
 			var firstLine = _reader.ReadLine();
 


### PR DESCRIPTION
As the MPD documentation says:
All data between the client and the server is encoded in UTF-8.

Using ASCII breaks commands like adding a song with non-ASCII characters
in filename.